### PR TITLE
Fix bug: missing dragging after map is moved

### DIFF
--- a/src/Path.Drag.js
+++ b/src/Path.Drag.js
@@ -18,7 +18,7 @@ L.PathDraggable = L.Draggable.extend({
 
   _onDown: function (e) {
     var first = e.touches ? e.touches[0] : e;
-    this._startPoint = new L.Point(first.clientX, first.clientY);
+    this._startPoint = this._path._map.mouseEventToLayerPoint(first);
     if (this._canvas && !this._path._containsPoint(this._startPoint)) { return; }
     L.Draggable.prototype._onDown.call(this, e);
   }


### PR DESCRIPTION
On the condition of `preferCanvas` in Leaflet 1.0, after I moved the map viewer, the dragging capability became disable.

I found out that the bug is caused by the error of `this._startPoint` in Line 21 of `Path.Drag.js`

```
this._startPoint = new L.Point(first.clientX, first.clientY);
```

A conversion is needed for the coordinate transformation from sreen coordinate to map layer coordinate.

Therefore, it should be replaced by `this._path._map.mouseEventToLayerPoint`.

```
this._startPoint = this._path._map.mouseEventToLayerPoint(first);
```
