### PR TITLE
Cleanup event listeners when path is removed from map

### DIFF
--- a/src/Path.Drag.js
+++ b/src/Path.Drag.js
@@ -133,6 +133,9 @@ L.Path.addInitHook(function () {
     this.once('add', function () {
       this.dragging.enable();
     });
+    this.once('remove', function() {
+      this.dragging.disable()
+    });
   }
 
 });


### PR DESCRIPTION
Without this change the `drag` events would still be triggered even after removing the layer from the map.